### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ void main() async {
         path,
         (request) => request.reply(200, {'message': 'Successfully mocked GET!'}),
       )
-      ..onGet(
+      ..onPost(
         path,
         (request) => request.reply(200, {'message': 'Successfully mocked POST!'}),
       );
 
-  final onGetResponse = await dio.get(path);
+  final getResponse = await dio.get(path);
   print(onGetResponse.data); // {message: Successfully mocked GET!}
 
-  final onPostResponse = await dio.post(path);
+  final postResponse = await dio.post(path);
   print(onPostResponse.data); // {message: Successfully mocked POST!}
 }
 ```


### PR DESCRIPTION
 **Fix example usage in README.md**

There is a typo in the example usage in README.md. Although the example was supposed to show mocking GET and POST request, it uses `onGet` method twice. See the pull request.

I also renamed the response variables from onGetResponse and onPostResponse to getResponse and postResponse because I think it is more simple and clarifying.  Can discuss about that though ;)